### PR TITLE
SDDM Theme fixes: Use a custom theme to set background image for SDDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,12 @@ Plasma
 ======
 
 1. Use Breeze Dark for Plasma, and Breeze for everything else.
-2. Set default wallpaper.
+2. Set default wallpaper to the chosen one in our annual wallpaper contest.
+3. Set default login screen/lock screen background in our annual wallpaper contest.
+
+Maintainer Notes
+================
+
+Default theme for SDDM is now maintained at `sddm-theme-breeze-aosc` package in the [aosc-os-abbs](https://github.com/AOSC-Dev/aosc-os-abbs/).
+
+This repository just sets the default SDDM theme to our forked Breeze theme. So please remember to update `autobuild/theme.conf` in the `sddm-breeze-aosc` package.

--- a/etc/sddm.conf.d/00-aosc-default.conf
+++ b/etc/sddm.conf.d/00-aosc-default.conf
@@ -1,0 +1,2 @@
+[Theme]
+Current=breeze-aosc

--- a/usr/share/sddm/themes/breeze/theme.conf.user
+++ b/usr/share/sddm/themes/breeze/theme.conf.user
@@ -1,3 +1,0 @@
-[General]
-background=/usr/share/wallpapers/Ailurus/contents/images/6000x4000.jpg
-type=image


### PR DESCRIPTION
This PR uses an almost identical theme to Breeze to set the background image for SDDM.

![telegram-cloud-photo-size-1-5026527555565498448-y](https://github.com/user-attachments/assets/bcbbd2cb-2d78-42ae-9887-3403b8f1d95a)
