### PR TITLE
feat: move fcitx environment from .xprofile to .config/environment.d

### DIFF
--- a/etc/skel/.config/environment.d/00-fcitx.conf
+++ b/etc/skel/.config/environment.d/00-fcitx.conf
@@ -1,0 +1,4 @@
+GTK_IM_MODULE=fcitx
+QT_IM_MODULE=fcitx
+QT5_IM_MODULE=fcitx
+XMODIFIERS=@im=fcitx

--- a/etc/skel/.xprofile
+++ b/etc/skel/.xprofile
@@ -1,4 +1,0 @@
-export GTK_IM_MODULE=fcitx
-export QT_IM_MODULE=fcitx
-export QT5_IM_MODULE=fcitx
-export XMODIFIERS=@im=fcitx


### PR DESCRIPTION
So it'll work for both X and Wayland.  Let's stop pretending Wayland did not need them despite Plasma Wayland insist to pretend that.